### PR TITLE
Update package.json for browserify support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "jquery.pointer-events-polyfill",
   "version": "0.2.4",
+  "main": "src/jquery.pointer-events-polyfill.js",
   "description": "Adds a javascript polyfill for the pointer-events css-property.",
   "repository": "https://github.com/screeny05/jquery.pointer-events-polyfill.git",
   "license": "MIT",


### PR DESCRIPTION
Browserify looks for a "main" field in package.json to define which file to take when you ```require()``` the module.